### PR TITLE
fix: several small bug fixes

### DIFF
--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -51,12 +51,20 @@ export default function Footer({ className }: FooterProps) {
           <Button variant="link">Quellcode</Button>
         </Link>
         <Link
-          href="https://neuland-ingolstadt.de/impressum.htm"
+          href="https://neuland-ingolstadt.de/legal/impressum"
           target="_blank"
           rel="noreferrer"
           passHref
         >
-          <Button variant="link">Impressum und Datenschutz</Button>
+          <Button variant="link">Impressum</Button>
+        </Link>
+        <Link
+          href="https://neuland-ingolstadt.de/legal/datenschutz"
+          target="_blank"
+          rel="noreferrer"
+          passHref
+        >
+          <Button variant="link">Datenschutz</Button>
         </Link>
       </ul>
     </footer>

--- a/data/tour/ingolstadt.json
+++ b/data/tour/ingolstadt.json
@@ -421,8 +421,8 @@
   },
   {
     "title": "Parkplatz Festplatz",
-    "description_de": "Kostenpflichtiger Parkplatz. Hier kostet das Tagesticket maximal 2,50 €. Zudem ist das Monatsticket für Studenten mit nur 17 € das billigste. ([Mehr Informationen](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-festplatz))",
-    "description_en": "Paid parking. Here the day ticket costs a maximum of 2.50 €. In addition, the monthly ticket for students is the cheapest at just 17 €. ([more information](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-festplatz))",
+    "description_de": "Kostenpflichtiger Parkplatz. Hier kostet das Tagesticket maximal 3 €. Zudem ist das Monatsticket für Studenten mit nur 22 € das billigste. ([Mehr Informationen](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-festplatz))",
+    "description_en": "Paid parking. Here the day ticket costs a maximum of 3 €. In addition, the monthly ticket for students is the cheapest at just 22 €. ([more information](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-festplatz))",
     "category": "nuetzlich",
     "lat": 48.77098,
     "lon": 11.42356

--- a/data/tour/ingolstadt.json
+++ b/data/tour/ingolstadt.json
@@ -453,8 +453,8 @@
   },
   {
     "title": "Parkplatz Hallenbad",
-    "description_de": "Kostenpflichtiger Parkplatz. Man kann hier ab 18 Uhr und am Sonntag gratis parken. Zudem kostet das Studentenmonatsticket 35 €. ([Mehr Informationen](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-hallenbad))",
-    "description_en": "Paid parking. You can park here for free after 6 p.m. and on Sundays. In addition, the monthly student ticket costs 35 €. ([more information](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-hallenbad))",
+    "description_de": "Kostenpflichtiger Parkplatz. Man kann hier ab 18 Uhr und am Sonntag gratis parken. Zudem kostet das Studentenmonatsticket 39 €. ([Mehr Informationen](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-hallenbad))",
+    "description_en": "Paid parking. You can park here for free after 6 p.m. and on Sundays. In addition, the monthly student ticket costs 39 €. ([more information](https://www.ingolstadt-ifg.de/parkin/parkeinrichtungen-der-ifg/parkplatz-hallenbad))",
     "category": "nuetzlich",
     "lat": 48.76126,
     "lon": 11.4199

--- a/data/tour/ingolstadt.json
+++ b/data/tour/ingolstadt.json
@@ -343,12 +343,12 @@
     "lon": 11.4317
   },
   {
-    "title": "Studierendenhaus",
+    "title": "Studierendenbüros",
     "description_de": "Büros der [Studierendenvertretung](https://www.thi.de/hochschule/ueber-uns/hochschulgremien/studierendenvertretung) und der [studentischen Vereine](https://www.thi.de/studium/studentisches-leben/studentische-vereine-an-der-thi).",
     "description_en": "Offices of the [student council](https://www.thi.de/en/university/university-profile/organisation/students-council) and the [student associations](https://www.thi.de/en/international/studies/campus-and-student-life/student-clubs-and-initiatives-at-thi).",
     "category": "hochschule",
-    "lat": 48.7676,
-    "lon": 11.43344
+    "lat": 48.76554,
+    "lon": 11.42978
   },
   {
     "title": "Campuswiese",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,9 +45,9 @@ interface MultiLang {
 
 export interface CLEvent {
   id: string
-  title: MultiLang
+  titles: MultiLang
   host: Host
-  startDateTime: Date | null
+  startDateTime: Date
   endDateTime: Date | null
   location: string | null
   eventUrl: string | null
@@ -85,7 +85,7 @@ export default function Home({ events }: HomeProps) {
     const data = [
       ...events,
       {
-        title: {
+        titles: {
           de: 'Mehr in der Neuland.App',
           en: 'More on Neuland.App',
         },
@@ -103,7 +103,7 @@ export default function Home({ events }: HomeProps) {
           <CardHeader className="flex flex-row items-start gap-0">
             <div className="mt-0 flex flex-1 flex-col">
               <span className="truncate text-lg font-bold">
-                {event.title.de}
+                {event.titles.de}
               </span>
               <span className="text-muted-foreground">{event.host.name}</span>
             </div>
@@ -359,10 +359,10 @@ export async function getServerSideProps() {
 					location
 					eventUrl
 					isMoodleEvent
-					descriptions {
-						de
-						en
-					}
+          titles {
+            de
+            en
+          }
 					host {
 						name
 						website
@@ -376,10 +376,10 @@ export async function getServerSideProps() {
   const eventsData = data.clEvents.map((event) => {
     return {
       ...event,
-      startDateTime: new Date(Number(event.startDateTime)).toISOString(),
+      startDateTime: new Date(event.startDateTime).toISOString(),
       endDateTime:
         event.endDateTime != null
-          ? new Date(Number(event.endDateTime)).toISOString()
+          ? new Date(event.endDateTime).toISOString()
           : null,
     }
   })


### PR DESCRIPTION
This pull request introduces updates to improve the structure and functionality of the codebase, including adjustments to UI components, data structure changes, and backend logic refinements. The most significant changes involve splitting legal links in the footer, renaming and restructuring event properties, and updating location data for a tour entry.

### UI Updates:
* [`components/ui/footer.tsx`](diffhunk://#diff-913b9281730c97b3bb11bcce243ac3e328a832d78347f13ac17cbb9247d05f17L54-R67): Split the "Impressum und Datenschutz" link into two separate links for "Impressum" and "Datenschutz," each pointing to distinct URLs.

### Data Structure Changes:
* [`pages/index.tsx`](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L48-R50): Renamed the `title` property to `titles` in the `CLEvent` interface and updated all references accordingly. [[1]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L48-R50) [[2]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L88-R88) [[3]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L106-R106) [[4]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L362-R362)
* [`pages/index.tsx`](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L379-R382): Modified the `startDateTime` and `endDateTime` properties in event data to always store `Date` objects instead of allowing `null` or `Number` types.

### Content Updates:
* [`data/tour/ingolstadt.json`](diffhunk://#diff-573f10dd522936d47dbbf4d304987b5fe96eda0a601af72c784cd3570409922eL346-R351): Renamed "Studierendenhaus" to "Studierendenbüros" and updated its latitude and longitude coordinates to reflect a more accurate location.